### PR TITLE
Updated jump reset to also check  that feet are touching ground

### DIFF
--- a/Assets/Prefabs/PlayerPlaceholder.prefab
+++ b/Assets/Prefabs/PlayerPlaceholder.prefab
@@ -136,6 +136,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 5
   jumpForce: 15
+  groundMask:
+    serializedVersion: 2
+    m_Bits: 64
 --- !u!114 &4316793158739803083
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -8,6 +8,7 @@ public class PlayerMovement : MonoBehaviour
     private bool hasJump = true;
     [SerializeField] float speed = 5f;
     [SerializeField] float jumpForce = 12f;
+    public LayerMask groundMask;
 
     CombatComponent _CombatControls;
     SpriteRenderer _SpriteRenderer;
@@ -43,7 +44,11 @@ public class PlayerMovement : MonoBehaviour
         // Reset jump
         if (rb.velocity.y == 0)
         {
-            hasJump = true;
+            // Check if feet have made contact
+            if(Physics2D.Raycast(rb.transform.position, -rb.transform.up, 2.0f, groundMask))
+            {
+                hasJump = true;
+            }
         }
 
         // Movement


### PR DESCRIPTION
<!---
Pull request template for 603 Platformer Game. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
- Fixed issue with jump being reset when player head hits ceiling.

## Please describe how to test
Just need to open any level with the player and test that they aren't able to keep double jumping when their head hits the ceiling.

## What Week of the 603 cycle is this due in?
Week 2