### PR TITLE
Breakaway platforms now get destroyed

### DIFF
--- a/Assets/Scripts/PlatformBehavior.cs
+++ b/Assets/Scripts/PlatformBehavior.cs
@@ -6,7 +6,7 @@ public class PlatformBehavior : MonoBehaviour
 {
     [Header("Breakaway")]
     [SerializeField] bool isBreakaway = false;
-    [SerializeField] float timeTillDrop = 0.8f;
+    [SerializeField] float timeTillDestroy = 0.8f;
 
     [Header("Movement")]
     [SerializeField] bool isMoving = false;
@@ -68,16 +68,16 @@ public class PlatformBehavior : MonoBehaviour
         if (isBreakaway && collision.gameObject.tag == "Player")
         {
             if (hasBroken) return;
-            StartCoroutine(AddRigidBody());
+            StartCoroutine(DestroyPlatform());
         }
     }
 
-    IEnumerator AddRigidBody() 
+    IEnumerator DestroyPlatform() 
     {
         hasBroken = true;
-        yield return new WaitForSeconds(timeTillDrop);
+        yield return new WaitForSeconds(timeTillDestroy);
 
-        // Add rigidbody to platform to make it fall
-        gameObject.AddComponent<Rigidbody2D>();
+        // Destory Platform
+        Destroy(gameObject);
     }
 }


### PR DESCRIPTION
<!---
Pull request template for 603 Platformer Game. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
- Breakaway platforms get destroyed now (instead of falling down).

## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
- Load BreakawayTest scene from Assets/Scenes/Test
- Play the scene
- Move the player on top of the platform

Ensure that:
- The platform is destroyed after a short delay

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->
![image](https://github.com/RohitK-RIT/603_G2_AlienPlatformer/assets/84484852/2626c686-f25b-42fa-b65c-bb6e32f67a47)

## What Week of the 603 cycle is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Final Week for Final Build