### PR TITLE
Fixed gravity to flip rightside up upon death

### DIFF
--- a/Assets/Scripts/Combat/CombatComponent.cs
+++ b/Assets/Scripts/Combat/CombatComponent.cs
@@ -5,6 +5,7 @@ using Features.Checkpoints;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using Features.Gravity_Modification;
 
 // Public enum for shooting directions
 public enum ShootDirection
@@ -44,11 +45,13 @@ public class CombatComponent : MonoBehaviour
 
     private CheckpointHandler _checkpointHandler;
     PlayerAnimationHandler _PlayerAnimControls;
+    Rigidbody2D _rb;
 
     private void Start()
     {
         _checkpointHandler = GetComponent<CheckpointHandler>();
         _PlayerAnimControls = GetComponent<PlayerAnimationHandler>();
+        _rb = GetComponent<Rigidbody2D>();
     }
 
     // Update is called once per frame
@@ -194,10 +197,16 @@ public class CombatComponent : MonoBehaviour
     {
         if (_checkpointHandler.TryUseCheckpoint())
         {
+            // Reset health
             health = 100f;
 
+            // Reset health bar
             if (healthBar)
                 healthBar.localScale = new Vector2(NormalizedHealth, 1f);
+
+            // Reset gravity
+            if (_rb.gravityScale < 0.0f)
+                GetComponent<GravitySwitch>().FlipObjectGravity();
         }
         else
             SceneManager.LoadScene(SceneManager.GetActiveScene().name);

--- a/Assets/Scripts/Features/Gravity Modification/GravitySwitch.cs
+++ b/Assets/Scripts/Features/Gravity Modification/GravitySwitch.cs
@@ -41,10 +41,10 @@ namespace Features.Gravity_Modification
         /// <summary>
         /// Function called to flip the player's gravity.
         /// </summary>
-        private void FlipObjectGravity()
+        public void FlipObjectGravity()
         {
             // Reverse the gravity and scale it up
-            var gravityScale = _rb.gravityScale * 2.0f;
+            var gravityScale = Mathf.Sign(_rb.gravityScale) * 4.0f;
             gravityScale = -gravityScale;
             _rb.gravityScale = gravityScale;
 


### PR DESCRIPTION
<!---
Pull request template for 603 Platformer Game. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
- Fixed gravity to flip rightside up every time player dies

## Please describe how to test
Play the level and flip gravity to land on a spike while upside down. If things work as expected, the alien should flip gravity back to normal upon respawn.

## What Week of the 603 cycle is this due in?
Week 3, final build